### PR TITLE
After the initial call to psutil.cpu_percent(), a short sleep (time.s…

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,24 +1,31 @@
 import psutil
 import time
-import threading
-import urwid
-import os
 
 def list_processes():
     print(f"\033[92;42m{'PID':<10}{'Name':<50}{'CPU Usage (%)':<15}{'Memory Usage (%)':<15}\033[0m")
     print("-" * 91)
 
     system_paths = ['C:\\Windows\\System32', 'C:\\Windows\\']
-
     current_user = psutil.Process().username()
 
-    for process in psutil.process_iter(["pid", "name", "cpu_percent", "memory_percent", "exe", "username",  "status"]):
+    # Initialize CPU usage to avoid immediate zero readings
+    psutil.cpu_percent(interval=0.1)
+    time.sleep(0.1)  # Short sleep to allow CPU usage to be recorded
+
+    # Iterate over processes
+    for process in psutil.process_iter(["pid", "name", "cpu_percent", "memory_percent", "exe", "username", "status"]):
         try:
-            name = process.info["name"]
             exe_path = process.info["exe"] if process.info["exe"] else ""
             username = process.info.get("username", "")
-            if process.info["status"] == psutil.STATUS_RUNNING and username == current_user and not any(exe_path.startswith(path) for path in system_paths):
-                print(f"\033[94m{process.info['pid']:<10}\033[0m\033[95m{process.info['name']:<50}\033[0m{process.info['cpu_percent']:<15}\033[96m{process.info['memory_percent']:<15}\033[0m")
+            if (process.info["status"] == psutil.STATUS_RUNNING and 
+                    username == current_user and 
+                    not any(exe_path.startswith(path) for path in system_paths)):
+                
+                # Get the actual CPU usage with a slight delay
+                time.sleep(0.1)  # Allow time for CPU usage to change
+                cpu_usage = process.cpu_percent(interval=0.1)
+                memory_usage = process.memory_percent()
+                print(f"\033[94m{process.info['pid']:<10}\033[0m\033[95m{process.info['name']:<50}\033[0m{cpu_usage:<15}\033[96m{memory_usage:<15}\033[0m")
 
         except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
             continue 
@@ -26,7 +33,7 @@ def list_processes():
 def kill_process(pid):
     try:
         process = psutil.Process(pid)
-        print(f"Terminating process {pid} ({process.name()})...");
+        print(f"Terminating process {pid} ({process.name()})...")
         process.terminate()
         process.wait(timeout=3)
         print(f"Process {pid} ({process.name()}) has been terminated.")


### PR DESCRIPTION
…leep(0.1)) was added. This delay allows the system to start tracking CPU activity.